### PR TITLE
Add v1_0/assets/coco_val_full.pbtxt

### DIFF
--- a/v1_0/assets/README.md
+++ b/v1_0/assets/README.md
@@ -1,3 +1,3 @@
 This folder contains assets for the v1.0 submission.
 
-The ground truth file 'coco_val_full.pbtxt` is from the COCO 2017 dataset (available at https://cocodataset.org/#home)
+The ground truth file `coco_val_full.pbtxt` is from the COCO 2017 dataset (available at https://cocodataset.org/#home)

--- a/v1_0/assets/README.md
+++ b/v1_0/assets/README.md
@@ -1,3 +1,4 @@
 This folder contains assets for the v1.0 submission.
 
-The ground truth file `coco_val_full.pbtxt` is from the COCO 2017 dataset (available at https://cocodataset.org/#home)
+The ground truth file `coco_val_full.pbtxt` is from the COCO 2017 dataset (available at https://cocodataset.org/#home).
+The `coco_val_full.pbtxt` is created from annotations distributed by the [COCO Consortium ](https://cocodataset.org/) and those contents are licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/legalcode)."

--- a/v1_0/assets/README.md
+++ b/v1_0/assets/README.md
@@ -1,0 +1,3 @@
+This folder contains assets for the v1.0 submission.
+
+The ground truth file 'coco_val_full.pbtxt` is from the COCO 2017 dataset (available at https://cocodataset.org/#home)


### PR DESCRIPTION
We need the ground truth file for the full COCO dataset in https://github.com/mlcommons/mobile_app_open. 
See https://github.com/mlcommons/mobile_app_open/issues/73 and https://github.com/mlcommons/mobile_app_open/pull/82
Since the COCO dataset is freely available. I assume this ground truth file also can be uploaded here.